### PR TITLE
update train_test.md

### DIFF
--- a/docs/en/user_guides/train_test.md
+++ b/docs/en/user_guides/train_test.md
@@ -123,7 +123,7 @@ which is specified by `work_dir` in the config file.
 ### Train with a single GPU
 
 ```shell
-CUDA_VISIBLE=0 python tools/train.py configs/example_config.py --work-dir work_dirs/example
+CUDA_VISIBLE_DEVICES=0 python tools/train.py configs/example_config.py --work-dir work_dirs/example
 ```
 
 ### Train with multiple nodes


### PR DESCRIPTION
## Motivation

The environment variable CUDA_VISIBLE=0 in the code "CUDA_VISIBLE=0 python tools/train.py configs/example_config.py --work-dir work_dirs/example" does not seem to be able to select GPU devices.

## Modification

Use the CUDA_VISIBLE_DEVICES environment variable instead：CUDA_VISIBLE=0 -> CUDA_VISIBLE_DEVICES=0
